### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord
+discord.py==0.16.12
 asyncio
 youtube-dl
 PyNaCl


### PR DESCRIPTION
Change `discord.py` to `discord.py==0.16.12`. The default version was now switched from async meaning installing discord.py without specifying a version will now give you the latest 'rewrite' version (v1.0+) not async. Async is nolonger supported.