### PR TITLE
Update "discord.py" to "discord.py==0.16.12" in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord
+discord.py==0.16.12
 asyncio
 youtube-dl
 PyNaCl


### PR DESCRIPTION
Change discord.py to discord.py==0.16.12 been getting alot of problem, for some reason it installed right when i had it as just discord.py weird some people may have a problem like this or maybe discord has now started using rewrite when one installs discord.py idk but chnage it to discord.py==0.16.12 in case